### PR TITLE
chore: remove unnecessary lodash override

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,7 +35,6 @@
     },
   },
   "overrides": {
-    "lodash": "4.17.23",
     "undici": "7.19.0",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "type": "module",
   "overrides": {
-    "undici": "7.19.0",
-    "lodash": "4.17.23"
+    "undici": "7.19.0"
   },
   "scripts": {
     "build": "bun run fix && tsc && bun run scripts/build.ts",


### PR DESCRIPTION
The same version can be specified without using overrides.