### PR TITLE
docs: add note about permission

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -49,6 +49,9 @@ on: [push]
 jobs:
   example:
     runs-on: ubuntu-latest
+    permissions:
+      # private repositoryにおいては必須
+      actions: read
     steps:
       # ワークフローの先頭でactions-workflow-metricsを実行
       - name: Start Workflow Telemetry

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ on: [push]
 jobs:
   example:
     runs-on: ubuntu-latest
+    permissions:
+      # Required for private repositories
+      actions: read
     steps:
       # Run actions-workflow-metrics at the beginning of the workflow
       - name: Start Workflow Telemetry


### PR DESCRIPTION
I add note about `actions: read` permission required for private repositories.