### PR TITLE
CI Add to Task List: client-idを使う

### DIFF
--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -17,7 +17,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }} # zizmor: ignore[secrets-outside-env]
+          client-id: ${{ secrets.PROJECT_AUTOMATION_APP_CLIENT_ID }} # zizmor: ignore[secrets-outside-env]
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }} # zizmor: ignore[secrets-outside-env]
           permission-organization-projects: write
           permission-pull-requests: read


### PR DESCRIPTION
https://github.com/dev-hato/actions-workflow-metrics/actions/runs/28938231342/job/85853822182#step:6:1

```
Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

`app-id` の代わりに `client-id` を使うようにします。