### PR TITLE
RenovateのnpmレジストリをFLATTに固定する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>dev-hato/renovate-config"],
-  "ignoreDeps": ["node-fetch"]
+  "ignoreDeps": ["node-fetch"],
+  "packageRules": [
+    {
+      "description": "Use the FLATT registry for npm packages",
+      "matchDatasources": ["npm"],
+      "registryUrls": ["https://npm.flatt.tech/"]
+    }
+  ]
 }


### PR DESCRIPTION
## 概要

- Renovate の npm datasource に `https://npm.flatt.tech/` を明示します。
- Bun と Dependabot は、既存の `.npmrc` にある同じレジストリ設定を引き続き使用します。

## 背景

PR #413 の lock-file maintenance では、`bun.lock` 内のレジストリ URL が空文字へ置き換わっています。空文字は未設定ではなく、Bun が設定済みのデフォルトレジストリを使う形式です。PR #413 の lockfile と既存の `.npmrc` を使い、空のキャッシュから frozen install を実行したところ、最初の取得先が `npm.flatt.tech` になることを確認しました。

一方、Renovate 自身が新しいバージョンを検索する npm datasource は、lockfile を更新する Bun とは別経路です。そのため、Renovate の検索先も FLATT に明示的に固定します。

## 影響

- Renovate の npm パッケージ検索先が FLATT に固定されます。
- Renovate の lockfile 更新、通常の Bun install、Dependabot は `.npmrc` を通して FLATT を使用します。
- 依存バージョンや `bun.lock` 自体は変更しません。

なお、`npm.flatt.tech` は tarball リクエストに対して npmjs.org への 302 リダイレクトを返します。この挙動は FLATT 側の仕様であり、本変更はクライアントの最初の接続先を FLATT に固定するものです。

## 検証

- `npx --yes --package renovate@44.3.2 renovate-config-validator renovate.json`
- `bunx prettier --check renovate.json`
- `npm config get registry`
- PR #413 の `bun.lock` を使った、空キャッシュからの `bun install --frozen-lockfile --verbose`
