### PR TITLE
bun.lockにFLATTのURLを保持する

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -32,7 +32,7 @@ jobs:
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
         uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        run: bun install
+        run: bun install --force --registry https://npm.flatt.tech/
       - run: bun run build
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
       - uses: dev-hato/actions-diff-pr-management@571be0d9572aaf77cdd315c12d6e73a1112910d7 # v2.2.6

--- a/bun.lock
+++ b/bun.lock
@@ -924,7 +924,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "https://npm.flatt.tech/prelude-ls/-/prelude-ls-1.2.1.tgz", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+    "prettier": ["prettier@3.9.6", "https://npm.flatt.tech/prettier/-/prettier-3.9.6.tgz", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 
     "prh": ["prh@5.4.4", "https://npm.flatt.tech/prh/-/prh-5.4.4.tgz", { "dependencies": { "commandpost": "^1.2.1", "diff": "^4.0.1", "js-yaml": "^3.9.1" }, "bin": { "prh": "./bin/prh" } }, "sha512-UATF+R/2H8owxwPvF12Knihu9aYGTuZttGHrEEq5NBWz38mREh23+WvCVKX3fhnIZIMV7ye6E1fnqAl+V6WYEw=="],
 


### PR DESCRIPTION
## 概要

`format` ワークフローの依存インストール時に、FLATT の npm レジストリをコマンドラインで明示し、Bun に依存解決情報を強制的に再生成させます。

```console
bun install --force --registry https://npm.flatt.tech/
```

## 背景

Renovate の lock-file maintenance では、Bun が `bun.lock` に記録された FLATT の URL を空文字へ正規化します。PR #415 で Renovate の npm datasource は FLATT に固定しましたが、`registryUrls` は依存バージョンの検索先を制御する設定であり、Bun が生成する lockfile の表記には影響しません。

既存の `format` ワークフローは Renovate と Dependabot を含むすべての依存更新PRで実行されるため、この共通経路で Bun のレジストリを明示します。

## 影響

- Renovate の `lockFileMaintenance` は引き続き有効です。
- Renovate と Dependabot のどちらが更新した場合も、`bun.lock` の npm パッケージ取得元を FLATT の URLへ戻します。
- `--force` によって依存パッケージを再取得するため、従来の `bun install` より通信量が増えます。
- `setup-takumi-guard-npm` を実行する既存の順序は変更しません。

## 検証

PR #413 の `bun.lock` を一時ディレクトリへコピーし、リポジトリで指定している Bun 1.3.14 で変更後のコマンドを実行しました。

- 実行前: FLATT URL 0件、空文字794件
- 実行後: FLATT URL 794件、空文字0件
- `node_modules` の生成を確認
- `bunx prettier --check .github/workflows/format.yml`
- `git diff --check`
